### PR TITLE
ci: switch shellcheck install to pip

### DIFF
--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install graphviz wheel pylint flake8 mypy
+        pip install graphviz wheel pylint flake8 mypy shellcheck-py
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
     - name: Build


### PR DESCRIPTION
This should fix the shellcheck failures. Windows still needs some work.